### PR TITLE
Sync project cards with horizontal menu scroll

### DIFF
--- a/public/assets/styles/main.css
+++ b/public/assets/styles/main.css
@@ -1015,6 +1015,11 @@ h6.section-title { font-size: 20px; }  /* Tiny sections */
     position: relative;
 }
 
+/* Enable vertical scroll while allowing JS-driven horizontal swipes on the card area */
+.project-display__card {
+    touch-action: pan-y;
+}
+
 /* Both sides have overflow */
 .project-display__menu.has-overflow {
     mask-image: linear-gradient(

--- a/public/index.html
+++ b/public/index.html
@@ -1338,10 +1338,54 @@
                 const menu = categoryContent.querySelector('.project-display__menu');
                 const cardContainer = categoryContent.querySelector('.project-display__card');
                 if (!menu || !cardContainer) return;
-        
+
+                // Click -> load template and set selection
                 menu.querySelectorAll('.project-display__menu-item').forEach(button => {
                     button.addEventListener('click', () => activateProject(menu, cardContainer, button.dataset.templateId));
                 });
+
+                // Touch swipe on card to change selected project
+                if (!cardContainer.dataset.swipeBound) {
+                    cardContainer.dataset.swipeBound = 'true';
+                    let touchStartX = 0;
+                    let touchStartY = 0;
+                    let tracking = false;
+                    const horizThreshold = 44; // px
+                    const vertBlockThreshold = 20; // allow small vertical jiggle
+
+                    cardContainer.addEventListener('touchstart', (e) => {
+                        const t = e.changedTouches[0];
+                        touchStartX = t.clientX;
+                        touchStartY = t.clientY;
+                        tracking = true;
+                    }, { passive: true });
+
+                    cardContainer.addEventListener('touchmove', (e) => {
+                        if (!tracking) return;
+                        const t = e.changedTouches[0];
+                        const dx = t.clientX - touchStartX;
+                        const dy = Math.abs(t.clientY - touchStartY);
+                        // If mostly horizontal movement and exceeds threshold, act and stop tracking
+                        if (Math.abs(dx) > horizThreshold && dy < vertBlockThreshold) {
+                            e.preventDefault();
+                            tracking = false;
+                            const items = Array.from(menu.querySelectorAll('.project-display__menu-item'));
+                            if (!items.length) return;
+                            const currentIdx = items.findIndex(btn => btn.getAttribute('aria-selected') === 'true');
+                            if (currentIdx === -1) return;
+                            const nextIdx = dx < 0 ? Math.min(items.length - 1, currentIdx + 1) : Math.max(0, currentIdx - 1);
+                            const target = items[nextIdx];
+                            if (target && nextIdx !== currentIdx) {
+                                activateProject(menu, cardContainer, target.dataset.templateId);
+                                target.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+                            }
+                        }
+                    }, { passive: false });
+
+                    cardContainer.addEventListener('touchend', () => { tracking = false; }, { passive: true });
+                    cardContainer.addEventListener('touchcancel', () => { tracking = false; }, { passive: true });
+                }
+
                 const initialProject = menu.querySelector('[aria-selected="true"]');
                 if (initialProject) activateProject(menu, cardContainer, initialProject.dataset.templateId);
                 
@@ -1607,12 +1651,68 @@
 
                 menu.addEventListener('scroll', () => handleProjectMenuOverflow(menu), { passive: true });
 
+                // Click and keyboard interaction
                 menu.querySelectorAll('.project-display__menu-item').forEach(button => {
                     button.addEventListener('click', () => {
                         activateProject(menu, cardContainer, button.dataset.templateId);
                         button.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
                     });
+                    button.addEventListener('keydown', (e) => {
+                        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                            const items = Array.from(menu.querySelectorAll('.project-display__menu-item'));
+                            const idx = items.indexOf(button);
+                            const nextIdx = e.key === 'ArrowRight' ? Math.min(items.length - 1, idx + 1) : Math.max(0, idx - 1);
+                            const target = items[nextIdx];
+                            if (target) {
+                                e.preventDefault();
+                                activateProject(menu, cardContainer, target.dataset.templateId);
+                                target.focus();
+                                target.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+                            }
+                        }
+                    });
                 });
+
+                // Touch swipe on card to change selected project
+                if (!cardContainer.dataset.swipeBound) {
+                    cardContainer.dataset.swipeBound = 'true';
+                    let touchStartX = 0;
+                    let touchStartY = 0;
+                    let tracking = false;
+                    const horizThreshold = 44; // px
+                    const vertBlockThreshold = 20; // small vertical forgiveness
+
+                    cardContainer.addEventListener('touchstart', (e) => {
+                        const t = e.changedTouches[0];
+                        touchStartX = t.clientX;
+                        touchStartY = t.clientY;
+                        tracking = true;
+                    }, { passive: true });
+
+                    cardContainer.addEventListener('touchmove', (e) => {
+                        if (!tracking) return;
+                        const t = e.changedTouches[0];
+                        const dx = t.clientX - touchStartX;
+                        const dy = Math.abs(t.clientY - touchStartY);
+                        if (Math.abs(dx) > horizThreshold && dy < vertBlockThreshold) {
+                            e.preventDefault();
+                            tracking = false;
+                            const items = Array.from(menu.querySelectorAll('.project-display__menu-item'));
+                            if (!items.length) return;
+                            const currentIdx = items.findIndex(btn => btn.getAttribute('aria-selected') === 'true');
+                            if (currentIdx === -1) return;
+                            const nextIdx = dx < 0 ? Math.min(items.length - 1, currentIdx + 1) : Math.max(0, currentIdx - 1);
+                            const target = items[nextIdx];
+                            if (target && nextIdx !== currentIdx) {
+                                activateProject(menu, cardContainer, target.dataset.templateId);
+                                target.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+                            }
+                        }
+                    }, { passive: false });
+
+                    cardContainer.addEventListener('touchend', () => { tracking = false; }, { passive: true });
+                    cardContainer.addEventListener('touchcancel', () => { tracking = false; }, { passive: true });
+                }
 
                 const initialProject = menu.querySelector('[aria-selected="true"]');
                 if (initialProject) activateProject(menu, cardContainer, initialProject.dataset.templateId);


### PR DESCRIPTION
Enable mobile swipe on starter project cards to navigate projects and synchronize with the menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7f067f5-6f4b-44eb-b520-af5a36a82ec6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7f067f5-6f4b-44eb-b520-af5a36a82ec6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

